### PR TITLE
[OSX] fix make deploy when compiling on OSX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -108,12 +108,6 @@ OSX_APP_BUILT=$(OSX_APP)/Contents/PkgInfo $(OSX_APP)/Contents/Resources/empty.lp
 osx_volname:
 	echo $(OSX_VOLNAME) >$@
 
-if BUILD_DARWIN
-$(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING)
-	$(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) -add-qt-tr $(OSX_QT_TRANSLATIONS) -translations-dir=$(QT_TRANSLATION_DIR) -dmg -fancy $(OSX_FANCY_PLIST) -verbose 2 -volname $(OSX_VOLNAME)
-
-deploydir: $(OSX_DMG)
-else
 APP_DIST_DIR=$(top_builddir)/dist
 APP_DIST_EXTRAS=$(APP_DIST_DIR)/.background/$(OSX_BACKGROUND_IMAGE) $(APP_DIST_DIR)/.DS_Store $(APP_DIST_DIR)/Applications
 
@@ -134,13 +128,12 @@ $(APP_DIST_DIR)/.background/$(OSX_BACKGROUND_IMAGE): $(OSX_BACKGROUND_IMAGE_DPIF
 	$(TIFFCP) -c none $(OSX_BACKGROUND_IMAGE_DPIFILES) $@
 
 $(APP_DIST_DIR)/.DS_Store: $(OSX_DSSTORE_GEN)
-	$(PYTHON) $< "$@" "$(OSX_VOLNAME)"
+	$(PYTHON2) $< "$@" "$(OSX_VOLNAME)"
 
 $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(OSX_APP_BUILT) $(OSX_PACKAGING)
 	INSTALLNAMETOOL=$(INSTALLNAMETOOL)  OTOOL=$(OTOOL) STRIP=$(STRIP) $(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) -translations-dir=$(QT_TRANSLATION_DIR) -add-qt-tr $(OSX_QT_TRANSLATIONS) -verbose 2
 
 deploydir: $(APP_DIST_EXTRAS)
-endif
 
 if TARGET_DARWIN
 appbundle: $(OSX_APP_BUILT)

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,7 @@ AC_PATH_TOOL(GCOV, gcov)
 AC_PATH_PROG(LCOV, lcov)
 AC_PATH_PROG(JAVA, java)
 AC_PATH_PROGS([PYTHON], [python3 python2.7 python2 python])
+AC_PATH_PROGS([PYTHON2], [python2.7 python2 python])
 AC_PATH_PROG(GENHTML, genhtml)
 AC_PATH_PROG([GIT], [git])
 AC_PATH_PROG(CCACHE,ccache)
@@ -301,6 +302,12 @@ case $host in
   *darwin*)
      TARGET_OS=darwin
      LEVELDB_TARGET_FLAGS="-DOS_MACOSX"
+     AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
+     AC_PATH_TOOL([OTOOL], [otool], otool)
+     AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
+     AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
+     AC_PATH_PROGS([IMAGEMAGICK_CONVERT], [convert],convert)
+     AC_PATH_PROGS([TIFFCP], [tiffcp],tiffcp)
      if  test x$cross_compiling != xyes; then
        BUILD_OS=darwin
        AC_CHECK_PROG([PORT],port, port)
@@ -344,13 +351,6 @@ case $host in
            BUILD_OS=darwin
            ;;
          *)
-           AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
-           AC_PATH_TOOL([OTOOL], [otool], otool)
-           AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
-           AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
-           AC_PATH_PROGS([IMAGEMAGICK_CONVERT], [convert],convert)
-           AC_PATH_PROGS([TIFFCP], [tiffcp],tiffcp)
-
            dnl libtool will try to strip the static lib, which is a problem for
            dnl cross-builds because strip attempts to call a hard-coded ld,
            dnl which may not exist in the path. Stripping the .a is not

--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -1,15 +1,8 @@
 ### MacDeploy ###
 
-For Snow Leopard (which uses [Python 2.6](http://www.python.org/download/releases/2.6/)), you will need the param_parser package:
-	
-	sudo easy_install argparse
-
 This script should not be run manually, instead, after building as usual:
 
 	make deploy
-
-During the process, the disk image window will pop up briefly where the fancy
-settings are applied. This is normal, please do not interfere.
 
 When finished, it will produce `Bitcoin-Core.dmg`.
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,6 +16,11 @@ Dependencies
 
     brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
 
+Builing the disk image (`make deploy`) requires `imagemagick`, `rsvg-convert` and `mkisofs` from the `dvdrtools` package together with some OSX relevant python packages
+
+    brew install dvdrtools imagemagick --with-librsvg
+    pip install ds_store mac_alias biplist
+
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
 Build Bitcoin Core


### PR DESCRIPTION
Should fix #8120.
There is a ugly issue of a python sub-package incompatibility https://github.com/bitcoin/bitcoin/issues/8134
