### PR TITLE
doc: Add privacy recommendation when running hidden service

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -114,3 +114,12 @@ Debian-based systems the user running bitcoind can be added to the debian-tor gr
 which has the appropriate permissions. An alternative authentication method is the use 
 of the `-torpassword` flag and a `hash-password` which can be enabled and specified in 
 Tor configuration.
+
+4. Privacy recommendations
+---------------------------
+
+- Do not add anything but bitcoin ports to the hidden service created in section 2.
+  If you run a web service too, create a new hidden service for that.
+  Otherwise it is trivial to link them, which may reduce privacy. Hidden
+  services created automatically (as in section 3) always have only one port
+  open.


### PR DESCRIPTION
Add "Do not add anything but bitcoin ports to the hidden service created in section 2.  If you run a web service too, create a new hidden service for that.  Otherwise it is trivial to link them, which may reduce privacy. Hidden services created automatically (as in section 3) always have only one port open."
